### PR TITLE
 Add ability to add a widget by pressing the enter key.

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ function simpleAddWidget() {
         // Trigger hiding of the add window
         addCancelButton.click();
     } else {
-        showToast("Unable to add widget: A title is required, unless the clock widget is used.");
+        showToast("Unable to add widget: A title is required.");
     }
 }
 


### PR DESCRIPTION
Requires focus on an input element within the menu with id 'addMenu'.
Does not work for color selection, and does also not apply to the 'cancel' button.