### PR TITLE
Change gridControl to class

### DIFF
--- a/src/gridControls.ts
+++ b/src/gridControls.ts
@@ -1,7 +1,6 @@
 "use strict";
 
 import {baseSettings, CTabWidget, CTabWidgetSerialized, linkSettings} from "./cTabWidgetTypeBase";
-import * as CTabWidgetTypes from './cTabWidgetType';
 import {cTabTypeMap, widgetNameList} from "./cTabWidgetTypeHelper";
 import Picker from 'vanilla-picker';
 import CTabSettings from "./settingsMenu";
@@ -15,28 +14,11 @@ import Muuri from "muuri";
     return (window as any).browser || (window as any).chrome || (window as any).msBrowser;
 })();
 
+// HTML element
 const styleElem = document.head.appendChild(document.createElement('style'));
 
-// grid return object
-interface CTabGrid {
-    initialize: () => void;
-    saveGrid: () => string;
-    createWidget: (type: string, settings: baseSettings, backgroundColor: string, textColor: string) => void;
-    debug: (sampleConfig: boolean, addSampleWidgets: boolean) => void;
-
-    setConfig: (config: CTabWidgetSerialized[]) => void;
-    getConfig: () => CTabWidgetSerialized[];
-}
-
-
-// module function; this will be exported
-function grid(): CTabGrid {
-    let grid: any;
-    let widgets: CTabWidget[] = [];
-    let widgetColorPickerOpen: boolean = false;
-    let dirty: boolean = false;
-    const options = {
-        // Muuri options
+class CTabGrid {
+    private muuriOptions = {
         dragEnabled: true,
         dragStartPredicate: {
             distance: 0,
@@ -67,19 +49,22 @@ function grid(): CTabGrid {
             }
         }
     };
+    private widgets: CTabWidget[] = [];
+    private widgetColorPickerOpen: boolean = false;
+    public grid: any;
+    private dirty: boolean = false;
 
-    // Function to be called to initialize the CTab page.
-    //  This function will
-    const initialize = function (): void {
+
+    constructor() {
         CTabSettings.initialize();
-        grid = new Muuri(".grid", options);
-        loadModel();
+        this.grid = new Muuri(".grid", this.muuriOptions);
+        this.loadModel();
 
         // @ts-ignore - no return for not showing a before-unload alert
-        window.onbeforeunload = function () {
+        window.onbeforeunload = () => {
             // dirty state is implemented loosely (did not care much before, dirty in the probability of change)
             // so an extra check is also added comparing the current state to the saved state
-            if (hasChanges() && CTabSettings.getShowUnsavedWarning()) {
+            if (this.hasChanges() && CTabSettings.getShowUnsavedWarning()) {
                 // You have unsaved changes on this page. Do you want to leave this page and discard your changes or stay on this page?
                 return "";
             }
@@ -89,147 +74,28 @@ function grid(): CTabGrid {
         // Start clocks
         startTime();
         document.querySelectorAll(".ctab-item-note").forEach(note => {
-            note.addEventListener('change', noteChanged);
-            note.addEventListener('keyup', noteChanged);
+            note.addEventListener('change', this.noteChanged);
+            note.addEventListener('keyup', this.noteChanged);
         });
         // Set dirty to false, since note widgets might have set the state to dirty
-        dirty = false;
+        this.dirty = false;
+    }
 
-    };
-
-    // Retrieve the current config from the browser's localstorage
-    const getConfig = (): CTabWidgetSerialized[] => {
-        let lsConfig = window.localStorage.getItem("CTabConfig") || "{}";
-        let config: CTabWidgetSerialized[] = [];
-        try {
-            config = JSON.parse(lsConfig);
-        } catch (error) {
-            console.error(`Config could not be parsed, found configuration:`, lsConfig);
-            console.error(error);
-        }
-        return config;
-    };
-
-    // Write param to localStorage
-    const setConfig = (config: CTabWidgetSerialized[]) => {
-        window.localStorage.setItem("CTabConfig", JSON.stringify(config));
-    };
-
-    // Returns message if save call is executed or not
-    const saveGrid: () => string = () => {
-        if (hasChanges()) {
-            service.setConfig(getDashboardConfig());
-            dirty = false;
-            return "Configuration saved!";
-        } else {
-            return "Nothing to save.";
-        }
-    };
-
-    const debug = (sampleConfig: boolean, addSampleWidgets: boolean) => {
-        console.log("debug:");
-        if (sampleConfig) {
-            console.log("using sample config");
-            let sampleConfiguration = [
-                {
-                    "settings": {"width": 1, "height": 1},
-                    "backgroundColor": "rgba(0,0,0,1)",
-                    "textColor": "rgba(209,20,20,1)",
-                    "id": 'i0',
-                    "type": "ClockWidget"
-                }];
-            service.setConfig(sampleConfiguration);
-        }
-        if (addSampleWidgets) {
-            addWidgetToGrid(new CTabWidgetTypes.LinkWidget(new Date().getTime().toString(), {
-                width: 1,
-                height: 1,
-                title: "hallo!", url: "https://github.com",
-                newTab: CTabSettings.getNewTab()
-            }, "rgba(255,255,255,0.5)", "rgba(0,0,0,1)"));
-        }
-    };
-
-    // Create a new widget object and add it to the dashboard.
-    const simpleAdd = function (type: string, settings: baseSettings, backgroundColor: string, textColor: string) {
-        dirty = true;
-        try {
-            addWidgetToGrid(
-                new (widgetTypes as any)[type]("i" + new Date().getTime().toString(), settings, backgroundColor, textColor));
-        } catch (e) {
-            if (type) {
-                console.log(`Widget type ${type} does not exist.`);
-            }
-            console.log(`Existing types are:`, widgetNameList);
-            console.log(cTabTypeMap);
-            console.log(widgetTypes);
-            console.error(e);
-        }
-    };
-
-    // Define return object
-    let service: CTabGrid = {
-        initialize: initialize,
-        saveGrid: saveGrid,
-        createWidget: simpleAdd,
-        debug: debug,
-        setConfig: setConfig,
-        getConfig: getConfig
-    };
-
-    // Toggle the colorpickers
-    const toggleWidgetColorPicker = (isOpen: boolean): void => {
-        widgetColorPickerOpen = isOpen;
-    };
-
-    // Listener for note widgets on change
-    // Used to track whether changes are made that need to be saved.
-    const noteChanged: () => void = () => {
-        dirty = true;
-    };
-
-    // Check if the current state of the dashboard is different from the saved state
-    const hasChanges: () => boolean = () => {
-        let saved = service.getConfig();
-        let current = getDashboardConfig();
-        // compare strings since object compare is always different with ==
-        if (JSON.stringify(saved) !== JSON.stringify(current)) {
-            if (dirty) {
-                return true;
-            }
-            console.log("Changes exist but dirty is false");
-            return true;
-        }
-        return false;
-    };
-
-    const removeWidget: (id: string) => void = function (id: string) {
-        // Get the outer muuri cell
-        let innerId = document.getElementById(id);
-        let cell = innerId!.parentElement!.parentElement;
-
-        if (cell) {
-            // remove from the grid (ui only)
-            grid.remove([cell], {removeElements: true, layout: true});
-            // also remove from widgets, otherwise no changes will be detected on saving.
-            widgets = widgets.filter((widget: CTabWidget) => widget.id !== id);
-            dirty = true;
-        }
-    };
-
+    // Load in the model and add every individual widget to the grid.
+    // Called by initialize;
     // Function that handles the addition of a widget to the actual grid.
     // Adding any necessary event listeners,
     // setting the body of the widget,
     // adding the control buttons to widgets,
     // and adapting the font size of the text using bigText
-    const addWidgetToGrid = function (widget: CTabWidget) {
+    public addWidgetToGrid = (widget: CTabWidget) => {
         let itemElem = document.createElement('div');
         itemElem.innerHTML = widget.widgetTemplate();
 
         let textColOpen = false;
 
         itemElem.firstChild!.addEventListener('mouseover', () => {
-            if (!widgetColorPickerOpen) {
+            if (!this.widgetColorPickerOpen) {
                 const controlPanel = document.getElementById(`controls-${widget.id}`)!;
                 const controlDragHandle = document.getElementById(`drag-handle-${widget.id}`)!;
                 const biggerZIndex = "4";
@@ -255,7 +121,7 @@ function grid(): CTabGrid {
                 controlDragHandle.classList.add('hidden');
             }
         });
-        grid.add(itemElem.firstChild, {index: widget.id});
+        this.grid.add(itemElem.firstChild, {index: widget.id});
 
         new Picker({
             parent: document.getElementById(`${widget.id}-text-color`)!,
@@ -270,11 +136,11 @@ function grid(): CTabGrid {
                 widget.textColor = newCol.rgbaString;
             },
             onOpen: () => {
-                toggleWidgetColorPicker(true);
+                this.toggleWidgetColorPicker(true);
                 textColOpen = true;
             },
             onClose: () => {
-                toggleWidgetColorPicker(false);
+                this.toggleWidgetColorPicker(false);
                 textColOpen = false;
             }
         });
@@ -297,17 +163,17 @@ function grid(): CTabGrid {
                 widget.backgroundColor = newCol.rgbaString;
             },
             onOpen: () => {
-                toggleWidgetColorPicker(true);
+                this.toggleWidgetColorPicker(true);
                 textColOpen = true;
             },
             onClose: () => {
-                toggleWidgetColorPicker(false);
+                this.toggleWidgetColorPicker(false);
                 textColOpen = false;
             }
         });
 
 
-        document.getElementById(`delete-${widget.id}`)!.addEventListener('click', () => removeWidget(widget.id));
+        document.getElementById(`delete-${widget.id}`)!.addEventListener('click', () => this.removeWidget(widget.id));
 
         if (widget instanceof widgetTypes.WeatherWidget) {
             widget.settings.width = widget.settings.width > 1 ? widget.settings.width : 2;
@@ -330,20 +196,10 @@ function grid(): CTabGrid {
             console.log(widget.id, widget.getType);
         }
 
-        widgets.push(widget);
+        this.widgets.push(widget);
     };
-
-
-    // Getter for the current config
-    const getDashboardConfig = function () {
-        return widgets.map(widget => widget.getConfig());
-    };
-
-    // Load in the model and add every individual widget to the grid.
-    // Called by initialize;
-    const loadModel = function () {
-        let widgetData: CTabWidgetSerialized[] = service.getConfig();
-        widgets = [];
+    public loadModel = () => {
+        let widgetData: CTabWidgetSerialized[] = this.getConfig();
         widgetData = Array.isArray(widgetData) ? widgetData : [];
 
         widgetData.filter((a: any) => a !== null).forEach((widget: CTabWidgetSerialized) => {
@@ -352,7 +208,7 @@ function grid(): CTabGrid {
                 if (widget.type === "LinkWidget") {
                     (widget.settings as linkSettings).newTab = CTabSettings.getNewTab();
                 }
-                addWidgetToGrid(new (widgetTypes as any)[widget.type](widget.id, widget.settings, widget.backgroundColor, widget.textColor));
+                this.addWidgetToGrid(new (widgetTypes as any)[widget.type](widget.id, widget.settings, widget.backgroundColor, widget.textColor));
             } catch (e) {
                 if (widget) {
                     console.log(`Widget type ${widget.type} does not exist.`);
@@ -365,11 +221,99 @@ function grid(): CTabGrid {
         });
 
     };
+    // Toggle the colorpickers
+    private toggleWidgetColorPicker = (isOpen: boolean): void => {
+        this.widgetColorPickerOpen = isOpen;
+    };
+    // Retrieve the current config from the browser's localstorage
+    public getConfig = (): CTabWidgetSerialized[] => {
+        let lsConfig = window.localStorage.getItem("CTabConfig") || "{}";
+        let config: CTabWidgetSerialized[] = [];
+        try {
+            config = JSON.parse(lsConfig);
+        } catch (error) {
+            console.error(`Config could not be parsed, found configuration:`, lsConfig);
+            console.error(error);
+        }
+        return config;
+    };
 
-    return service;
+    public removeWidget: (id: string) => void = (id: string) => {
+        // Get the outer muuri cell
+        let innerId = document.getElementById(id);
+        let cell = innerId!.parentElement!.parentElement;
+
+        if (cell) {
+            // remove from the grid (ui only)
+            this.grid.remove([cell], {removeElements: true, layout: true});
+            // also remove from widgets, otherwise no changes will be detected on saving.
+            this.widgets = this.widgets.filter((widget: CTabWidget) => widget.id !== id);
+            this.dirty = true;
+        }
+    };
+
+    // Write param to localStorage
+    public setConfig = (config: CTabWidgetSerialized[]) => {
+        window.localStorage.setItem("CTabConfig", JSON.stringify(config));
+    };
+
+
+    // Returns message if save call is executed or not
+    public saveGrid: () => string = () => {
+        if (this.hasChanges()) {
+            this.setConfig(this.getDashboardConfig());
+            this.dirty = false;
+            return "Configuration saved!";
+        } else {
+            return "Nothing to save.";
+        }
+    };
+
+    // Create a new widget object and add it to the dashboard.
+    public createWidget = (type: string, settings: baseSettings, backgroundColor: string, textColor: string) => {
+        this.dirty = true;
+        try {
+            this.addWidgetToGrid(
+                new (widgetTypes as any)[type]("i" + new Date().getTime().toString(), settings, backgroundColor, textColor));
+        } catch (e) {
+            if (type) {
+                console.log(`Widget type ${type} does not exist.`);
+            }
+            console.log(`Existing types are:`, widgetNameList);
+            console.log(cTabTypeMap);
+            console.log(widgetTypes);
+            console.error(e);
+        }
+    };
+
+    // Listener for note widgets on change
+    // Used to track whether changes are made that need to be saved.
+    private noteChanged: () => void = () => {
+        this.dirty = true;
+    };
+
+    // Check if the current state of the dashboard is different from the saved state
+    private hasChanges: () => boolean = () => {
+        let saved = this.getConfig();
+        let current = this.getDashboardConfig();
+        // compare strings since object compare is always different with ==
+        if (JSON.stringify(saved) !== JSON.stringify(current)) {
+            if (this.dirty) {
+                return true;
+            }
+            console.log("Changes exist but dirty is false");
+            return true;
+        }
+        return false;
+    };
+
+
+    // Getter for the current config
+    private getDashboardConfig = () => {
+        return this.widgets.map(widget => widget.getConfig());
+    };
 
 }
-
 
 // Independent functions
 // From w3 to add clock
@@ -390,4 +334,4 @@ function startTime() {
     }
 }
 
-export default grid;
+export default CTabGrid;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-import grid from './gridControls';
 import {baseSettings, linkSettings, titleSettings} from "./cTabWidgetTypeBase";
 import {widgetNameList} from "./cTabWidgetTypeHelper";
 import CTabSettings from "./settingsMenu";
 // @ts-ignore streamsaver is no module, but adds to global scope
 import streamSaver from 'streamsaver';
+import CTabGrid from "./gridControls";
 
 
 (window as any).browser = (() => {
@@ -30,12 +30,11 @@ function showToast(message: string): void {
 }
 
 
-let CTabGrid = grid();
-CTabGrid.initialize();
+let cTabGrid = new CTabGrid();
 
 // Save the grid and show the result to user using toastBox.
 function saveGrid(): void {
-    const saveResult = CTabGrid.saveGrid();
+    const saveResult = cTabGrid.saveGrid();
     showToast(saveResult);
 }
 


### PR DESCRIPTION
Changing the structure of the gridControl export. Instead of returning a custom object with functions attached to it, make use of the JS class structure.

~~Wait for category implementation before merging.~~