### PR TITLE
Change gridControl to class

### DIFF
--- a/src/gridControls.ts
+++ b/src/gridControls.ts
@@ -17,7 +17,7 @@ import Muuri from "muuri";
 // HTML element
 const styleElem = document.head.appendChild(document.createElement('style'));
 
-class CTabGrid {
+export class CTabGrid {
     private muuriOptions = {
         dragEnabled: true,
         dragStartPredicate: {
@@ -88,7 +88,7 @@ class CTabGrid {
     // setting the body of the widget,
     // adding the control buttons to widgets,
     // and adapting the font size of the text using bigText
-    public addWidgetToGrid = (widget: CTabWidget) => {
+    public addWidgetToGrid(widget: CTabWidget): void {
         let itemElem = document.createElement('div');
         itemElem.innerHTML = widget.widgetTemplate();
 
@@ -198,7 +198,8 @@ class CTabGrid {
 
         this.widgets.push(widget);
     };
-    public loadModel = () => {
+
+    public loadModel(): void {
         let widgetData: CTabWidgetSerialized[] = this.getConfig();
         widgetData = Array.isArray(widgetData) ? widgetData : [];
 
@@ -221,12 +222,14 @@ class CTabGrid {
         });
 
     };
+
     // Toggle the colorpickers
-    private toggleWidgetColorPicker = (isOpen: boolean): void => {
+    private toggleWidgetColorPicker(isOpen: boolean): void {
         this.widgetColorPickerOpen = isOpen;
     };
+
     // Retrieve the current config from the browser's localstorage
-    public getConfig = (): CTabWidgetSerialized[] => {
+    public getConfig(): CTabWidgetSerialized[] {
         let lsConfig = window.localStorage.getItem("CTabConfig") || "{}";
         let config: CTabWidgetSerialized[] = [];
         try {
@@ -238,7 +241,7 @@ class CTabGrid {
         return config;
     };
 
-    public removeWidget: (id: string) => void = (id: string) => {
+    public removeWidget(id: string): void {
         // Get the outer muuri cell
         let innerId = document.getElementById(id);
         let cell = innerId!.parentElement!.parentElement;
@@ -253,13 +256,13 @@ class CTabGrid {
     };
 
     // Write param to localStorage
-    public setConfig = (config: CTabWidgetSerialized[]) => {
+    public setConfig (config: CTabWidgetSerialized[]): void {
         window.localStorage.setItem("CTabConfig", JSON.stringify(config));
     };
 
 
     // Returns message if save call is executed or not
-    public saveGrid: () => string = () => {
+    public saveGrid(): string {
         if (this.hasChanges()) {
             this.setConfig(this.getDashboardConfig());
             this.dirty = false;
@@ -270,7 +273,7 @@ class CTabGrid {
     };
 
     // Create a new widget object and add it to the dashboard.
-    public createWidget = (type: string, settings: baseSettings, backgroundColor: string, textColor: string) => {
+    public createWidget(type: string, settings: baseSettings, backgroundColor: string, textColor: string): void {
         this.dirty = true;
         try {
             this.addWidgetToGrid(
@@ -288,12 +291,12 @@ class CTabGrid {
 
     // Listener for note widgets on change
     // Used to track whether changes are made that need to be saved.
-    private noteChanged: () => void = () => {
+    private noteChanged(): void {
         this.dirty = true;
     };
 
     // Check if the current state of the dashboard is different from the saved state
-    private hasChanges: () => boolean = () => {
+    private hasChanges(): boolean {
         let saved = this.getConfig();
         let current = this.getDashboardConfig();
         // compare strings since object compare is always different with ==
@@ -309,7 +312,7 @@ class CTabGrid {
 
 
     // Getter for the current config
-    private getDashboardConfig = () => {
+    private getDashboardConfig(): CTabWidgetSerialized[] {
         return this.widgets.map(widget => widget.getConfig());
     };
 
@@ -317,7 +320,7 @@ class CTabGrid {
 
 // Independent functions
 // From w3 to add clock
-function startTime() {
+function startTime(): void {
     let clocks = document.querySelectorAll('.ctab-item-clock');
     if (clocks.length > 0) {
         const todayDate = new Date();

--- a/src/gridControlsDebug.ts
+++ b/src/gridControlsDebug.ts
@@ -1,0 +1,30 @@
+import CTabGrid from './gridControls'
+import CTabSettings from "./settingsMenu";
+import {LinkWidget} from './cTabWidgetType';
+
+export {
+    debugSetGridToUseSampleConfig,
+    debugAddSampleWidgetToGrid
+}
+
+function debugSetGridToUseSampleConfig(ctab: CTabGrid): void {
+    console.log("using sample config");
+    let sampleConfiguration = [
+        {
+            "settings": {"width": 1, "height": 1},
+            "backgroundColor": "rgba(0,0,0,1)",
+            "textColor": "rgba(209,20,20,1)",
+            "id": 'i0',
+            "type": "ClockWidget"
+        }];
+    ctab.setConfig(sampleConfiguration);
+}
+
+function debugAddSampleWidgetToGrid(ctab: CTabGrid): void {
+    ctab.addWidgetToGrid(new LinkWidget(new Date().getTime().toString(), {
+        width: 1,
+        height: 1,
+        title: "hallo!", url: "https://github.com",
+        newTab: CTabSettings.getNewTab()
+    }, "rgba(255,255,255,0.5)", "rgba(0,0,0,1)"));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import CTabSettings from "./settingsMenu";
 // @ts-ignore streamsaver is no module, but adds to global scope
 import streamSaver from 'streamsaver';
 import CTabGrid from "./gridControls";
-
+import {debugSetGridToUseSampleConfig, debugAddSampleWidgetToGrid} from './gridControlsDebug';
 
 (window as any).browser = (() => {
     return (<any>window).browser || (<any>window).chrome || (<any>window).msBrowser;
@@ -150,7 +150,7 @@ function addWidget(): void {
         showToast(`Unable to add widget:${errorList.reduce((acc, curr) => " " + acc + curr, "")}.`);
     } else {
 
-        CTabGrid.createWidget(widgetTypeChanger.value, settings, bgcolor!.value, textcolor!.value);
+        cTabGrid.createWidget(widgetTypeChanger.value, settings, bgcolor!.value, textcolor!.value);
         title!.value = "";
         url!.value = "";
 
@@ -226,8 +226,8 @@ loadBackupButton!.addEventListener('change', () => {
 
 // disable dev mode by default
 devSwitch('none');
-clearButton!.addEventListener('click', () => CTabGrid.debug(true, false));
-debugButton!.addEventListener('click', () => CTabGrid.debug(false, true));
+clearButton!.addEventListener('click', () => debugSetGridToUseSampleConfig(cTabGrid));
+debugButton!.addEventListener('click', () => debugAddSampleWidgetToGrid(cTabGrid));
 
 backupButton!.addEventListener('click', saveCurrentConfig);
 devEnabledCheckbox!.addEventListener('change', (a) => {
@@ -241,22 +241,23 @@ devEnabledCheckbox!.addEventListener('change', (a) => {
 
 devSaveButton!.addEventListener('click', () => {
     let config = JSON.parse(configField!.value);
-    CTabGrid.setConfig(config);
+    cTabGrid.setConfig(config);
 });
+
 devOpacityButton!.addEventListener('click', () => {
     let config = configField!.value;
     configField!.value = config.replace(/(backgroundColor":"rgba\([0-9]+,[0-9]+,[0-9]+,)([0-9.]+)((?=\)"))/gm, "$1 0.5$3");
 
 });
 
-configField!.value = prettyPrintConfig(CTabGrid.getConfig());
+configField!.value = prettyPrintConfig(cTabGrid.getConfig());
 
 // saving config to file
 function saveCurrentConfig() {
     const fileStream = streamSaver.createWriteStream(`config-${new Date().valueOf()}.json`);
     const writer = fileStream.getWriter();
     const encoder = new TextEncoder;
-    let data = JSON.stringify(CTabGrid.getConfig());
+    let data = JSON.stringify(cTabGrid.getConfig());
     let uint8array = encoder.encode(data + "\n\n");
 
     writer.write(uint8array);
@@ -284,7 +285,7 @@ try {
         // If user checks the disableAddWidgetOnBookmark setting, then we don't want to add a bookmark.
         // Hence, if it is not checked, we do want to add a bookmark.
         if (!CTabSettings.getAddWidgetOnBookmarkIsDisabled()) {
-            CTabGrid.createWidget("LinkWidget", {
+            cTabGrid.createWidget("LinkWidget", {
                 width: 1,
                 height: 1,
                 title: (bookmark.title as string),


### PR DESCRIPTION
original message (PR #49):

```
Changing the structure of the gridControl export. Instead of returning a custom object with functions attached to it, make use of the JS class structure.

Wait for category implementation before merging.
```

![image](https://user-images.githubusercontent.com/5955761/61177108-ae680c80-a5bc-11e9-95a2-736d9822af12.png)
