### PR TITLE
Add custom ordering for widgets

### DIFF
--- a/src/cTabWidgetTypeBase.ts
+++ b/src/cTabWidgetTypeBase.ts
@@ -81,6 +81,10 @@ export interface BaseSettings {
 
     // Tags allow users to categorize their widgets
     tags: string[];
+
+    // value used to enumerate where a cell should be ordered on the grid as decided by a user (after dragging
+    // and dropping a cell)
+    orderIndex: number;
 }
 
 // Serialized version of a CTab Widget

--- a/src/index.html
+++ b/src/index.html
@@ -27,6 +27,7 @@
                 <option value="alpha-asc">title</option>
                 <option value="alpha-desc">title (descending)</option>
                 <option value="tag-alpha">tag (alphabetical)</option>
+                <option value="user-order">user order</option>
             </select>
         </div>
     </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,9 @@ sortingDropdown!.addEventListener('change', () => {
         case "tag-alpha":
             cTabGrid.grid.sort("tagAlpha");
             break;
+        case "user-order":
+            cTabGrid.grid.sort("orderIndex");
+            break;
         case "id-asc" :
         default:
             cTabGrid.grid.sort("id");
@@ -140,7 +143,7 @@ function addWidget(): void {
     let bgcolor: HTMLInputElement | null = document.querySelector('#addBGC');
     let textcolor: HTMLInputElement | null = document.querySelector('#addTC');
 
-    let settings: BaseSettings = {width: 1, height: 1, tags: []};
+    let settings: BaseSettings = {width: 1, height: 1, tags: [], orderIndex: Number.MAX_SAFE_INTEGER};
     let errorList: string[] = [];
     switch (widgetTypeChanger.value) {
         case "BuienradarWidget":


### PR DESCRIPTION
This addition should lay the foundation for user defined ordering of widgets. 

Aside from questions like whether this ordering should be the default or not, or what name it should be given, there is one important question for the implementation: "what should happen when a user drags a widget (and does it matter whether we have the custom ordering selected)?". 

Right now, after and element has been dragged, the custom ordering state is updated for both the state used by the grid sorting algorithm as well as the state which can be saved to the local storage. We also currently do not take into account which ordering mode is selected. Thus, we always update the grid ordering to the current state regardless of the selected ordering. This means that if we have a custom ordering A (which we can view by selecting "user order" in the ordering drop-down) and we have currently selected the grid ordering "date added" (B), then if we drag a widget in the current grid view to some place in the grid (B'), B' will overwrite the custom order state A. Whether that is desired is to be determined :).